### PR TITLE
Добавлена проверка необходимости доставки 

### DIFF
--- a/src/Helpers/CheckoutHelper.php
+++ b/src/Helpers/CheckoutHelper.php
@@ -93,6 +93,10 @@ namespace Cdek\Helpers {
 
         public static function restoreCheckoutFields(array $fields): array
         {
+            if (!WC()->cart->needs_shipping()) {
+                return $fields;
+            }
+            
             $checkout = WC()->checkout();
 
             $originalFields = $checkout->get_checkout_fields('billing');


### PR DESCRIPTION
Если в корзине виртуальный товар,  то нет необходимости доставки,  но если включены международные отправления  добавляются поля и появляется ошибка,  пример https://github.com/cdek-it/wordpress/issues/26
также писали об этом в обращении **SDPO-78265**